### PR TITLE
Ensure single instance of generators in HumanoIDs class

### DIFF
--- a/src/HumanoIDs.php
+++ b/src/HumanoIDs.php
@@ -6,8 +6,8 @@ namespace RobThree\HumanoID;
 
 final class HumanoIDs
 {
-    private static HumanoID $zooGenerator;
-    private static HumanoID $spaceGenerator;
+    private static HumanoID $zooGenerator = null;
+    private static HumanoID $spaceGenerator = null;
 
     public static function zooIdGenerator(
         ?string $separator = '-',

--- a/src/HumanoIDs.php
+++ b/src/HumanoIDs.php
@@ -13,7 +13,7 @@ final class HumanoIDs
         ?string $separator = '-',
         ?WordFormatOption $format = null
     ): HumanoID {
-        if (self::$zooGenerator === null)
+        if (self::$zooGenerator === null) {
             self::$zooGenerator = new HumanoID(
                 json_decode(
                     file_get_contents(__DIR__ . '/../data/zoo-words.json'),
@@ -23,6 +23,7 @@ final class HumanoIDs
                 $separator,
                 $format
             );
+        }
         return self::$zooGenerator;
     }
 
@@ -30,16 +31,17 @@ final class HumanoIDs
         ?string $separator = '-',
         ?WordFormatOption $format = null
     ): HumanoID {
-        if (self::$spaceGenerator === null)
+        if (self::$spaceGenerator === null) {
             self::$spaceGenerator = new HumanoID(
-            json_decode(
-                file_get_contents(__DIR__ . '/../data/space-words.json'),
-                true
-            ),
-            null,
-            $separator,
-            $format
-        );
+                json_decode(
+                    file_get_contents(__DIR__ . '/../data/space-words.json'),
+                    true
+                ),
+                null,
+                $separator,
+                $format
+            );
+        }
         return self::$spaceGenerator;
     }
 }

--- a/src/HumanoIDs.php
+++ b/src/HumanoIDs.php
@@ -6,8 +6,8 @@ namespace RobThree\HumanoID;
 
 final class HumanoIDs
 {
-    private static HumanoID $zooGenerator = null;
-    private static HumanoID $spaceGenerator = null;
+    private static ?HumanoID $zooGenerator = null;
+    private static ?HumanoID $spaceGenerator = null;
 
     public static function zooIdGenerator(
         ?string $separator = '-',

--- a/src/HumanoIDs.php
+++ b/src/HumanoIDs.php
@@ -6,26 +6,32 @@ namespace RobThree\HumanoID;
 
 final class HumanoIDs
 {
+    private static HumanoID $zooGenerator;
+    private static HumanoID $spaceGenerator;
+
     public static function zooIdGenerator(
         ?string $separator = '-',
         ?WordFormatOption $format = null
     ): HumanoID {
-        return new HumanoID(
-            json_decode(
-                file_get_contents(__DIR__ . '/../data/zoo-words.json'),
-                true
-            ),
-            null,
-            $separator,
-            $format
-        );
+        if (self::$zooGenerator === null)
+            self::$zooGenerator = new HumanoID(
+                json_decode(
+                    file_get_contents(__DIR__ . '/../data/zoo-words.json'),
+                    true
+                ),
+                null,
+                $separator,
+                $format
+            );
+        return self::$zooGenerator;
     }
 
     public static function spaceIdGenerator(
         ?string $separator = '-',
         ?WordFormatOption $format = null
     ): HumanoID {
-        return new HumanoID(
+        if (self::$spaceGenerator === null)
+            self::$spaceGenerator = new HumanoID(
             json_decode(
                 file_get_contents(__DIR__ . '/../data/space-words.json'),
                 true
@@ -34,5 +40,6 @@ final class HumanoIDs
             $separator,
             $format
         );
+        return self::$spaceGenerator;
     }
 }


### PR DESCRIPTION
See #10, testcase 2. The `HumanoIDs` class should ensure only one instance of the provided generators will be created. This does that.