### PR TITLE
DX: Improve the builder usability and make silent issues louder

### DIFF
--- a/demo.php
+++ b/demo.php
@@ -1,6 +1,7 @@
 <?php
 
 use RobThree\HumanoID\HumanoIDs;
+use RobThree\HumanoID\WordFormatOption;
 
 require_once __DIR__ . '/vendor/autoload.php';
 
@@ -12,7 +13,15 @@ $zooIdGen = HumanoIDs::zooIdGenerator();
 // Convert ID to HumanoID
 $zooId = $zooIdGen->create(96712);
 echo sprintf("HumanoID   : %s\n", $zooId);
-    
+// Convert back to ID
+$id = $zooIdGen->parse($zooId);
+echo sprintf("Decoded ID : %d\n", $id);
+
+// Do it again with a different separator...will throw a warning...
+echo "This next one will throw a warning...\n";
+$zooIdGen = HumanoIDs::zooIdGenerator('_', WordFormatOption::upper(), new \RobThree\HumanoID\Obfuscatories\MissyElliottObfuscator());
+$zooId = $zooIdGen->create(96712);
+echo sprintf("HumanoID   : %s\n", $zooId);
 // Convert back to ID
 $id = $zooIdGen->parse($zooId);
 echo sprintf("Decoded ID : %d\n", $id);

--- a/src/HumanoIDs.php
+++ b/src/HumanoIDs.php
@@ -7,13 +7,16 @@ namespace RobThree\HumanoID;
 final class HumanoIDs
 {
     private static ?HumanoID $zooGenerator = null;
+    private static ?array $zooGeneratorArgs = null;
     private static ?HumanoID $spaceGenerator = null;
+    private static ?array $spaceGeneratorArgs = null;
 
     public static function zooIdGenerator(
         ?string $separator = '-',
         ?WordFormatOption $format = null
     ): HumanoID {
         if (self::$zooGenerator === null) {
+            self::$zooGeneratorArgs = func_get_args();
             self::$zooGenerator = new HumanoID(
                 json_decode(
                     file_get_contents(__DIR__ . '/../data/zoo-words.json'),
@@ -24,6 +27,25 @@ final class HumanoIDs
                 $format
             );
         }
+
+        if (self::$zooGeneratorArgs !== func_get_args()) {
+            trigger_error(
+                "Calling zooIdGenerator with different arguments will result in a new instance of HumanoID being created each time. " .
+                "Instead consider constructing a new instance of HumanoID directly",
+                E_USER_WARNING
+            );
+            self::$zooGenerator = new HumanoID(
+                json_decode(
+                    file_get_contents(__DIR__ . '/../data/zoo-words.json'),
+                    true
+                ),
+                null,
+                $separator,
+                $format,
+                $obfuscator
+            );
+        }
+
         return self::$zooGenerator;
     }
 
@@ -32,6 +54,7 @@ final class HumanoIDs
         ?WordFormatOption $format = null
     ): HumanoID {
         if (self::$spaceGenerator === null) {
+            self::$spaceGeneratorArgs = func_get_args();
             self::$spaceGenerator = new HumanoID(
                 json_decode(
                     file_get_contents(__DIR__ . '/../data/space-words.json'),
@@ -42,6 +65,25 @@ final class HumanoIDs
                 $format
             );
         }
+
+        if (self::$spaceGeneratorArgs !== func_get_args()) {
+            trigger_error(
+                "Calling spaceIdGenerator with different arguments will result in a new instance of HumanoID being created each time. " .
+                "Instead consider constructing a new instance of HumanoID directly",
+                E_USER_WARNING
+            );
+            self::$spaceGenerator = new HumanoID(
+                json_decode(
+                    file_get_contents(__DIR__ . '/../data/space-words.json'),
+                    true
+                ),
+                null,
+                $separator,
+                $format,
+                $obfuscator
+            );
+        }
+
         return self::$spaceGenerator;
     }
 }

--- a/src/HumanoIDs.php
+++ b/src/HumanoIDs.php
@@ -41,8 +41,7 @@ final class HumanoIDs
                 ),
                 null,
                 $separator,
-                $format,
-                $obfuscator
+                $format
             );
         }
 
@@ -79,8 +78,7 @@ final class HumanoIDs
                 ),
                 null,
                 $separator,
-                $format,
-                $obfuscator
+                $format
             );
         }
 

--- a/tests/BasicBuilderTest.php
+++ b/tests/BasicBuilderTest.php
@@ -45,4 +45,11 @@ class BasicBuilderTest extends BaseTestCase
 
         $this->assertMatchesJsonSnapshot($firstTwoDozenIds);
     }
+
+    public function testDefaultGeneratorWithNewArgsThrows(): void
+    {
+        $this->expectWarning();
+        $this->expectWarningMessage("Calling zooIdGenerator with different arguments will result in a new instance of HumanoID being created each time. Instead consider constructing a new instance of HumanoID directly");
+        HumanoIDs::zooIdGenerator('_');
+    }
 }

--- a/tests/SpaceBuilderTest.php
+++ b/tests/SpaceBuilderTest.php
@@ -56,4 +56,11 @@ class SpaceBuilderTest extends BaseTestCase
 
         $this->assertMatchesJsonSnapshot($firstTwoDozenIds);
     }
+
+    public function testDefaultGeneratorWithNewArgsThrows(): void
+    {
+        $this->expectWarning();
+        $this->expectWarningMessage("Calling spaceIdGenerator with different arguments will result in a new instance of HumanoID being created each time. Instead consider constructing a new instance of HumanoID directly");
+        HumanoIDs::spaceIdGenerator('_');
+    }
 }


### PR DESCRIPTION
This PR was something I just noticed while working on the other one that feels like a pretty bad DX currently. So I've created a new PR for this change as -if we choose to merge- it's a good improvement/fix that should ship before the obfuscation stuff might be complete.

TL;DR: If a user utilizes our basic builders provided by `HumanoIDs` then they are inherently using singletons provided by the library. This obviously means that the parameters they provide will only be used on the first invocation where the singleton is created.

IMO, we should either: a) make it obvious they are doing it wrong but give them the results they want (what this PR provides), or b) make it obvious they are doing it wrong and bail out.

---

The root of the concern here is that if users do not give consistent parameters to our builders, then -as things stand now- they may get varying results depending on which call initializes the singleton.

Meaning that in general they should get consistent results -and the changing parameters won't have any affect for subsequent invocations- however if something in their code changes which invocation runs first that could change results. 

Ultimately this is something that becomes obvious in PHPUnit as it randomizes tests. Which is how I initially identified this shortcoming and came up with a way to resolve it and hopefully prevent future developer confusion.